### PR TITLE
Add speakOnDemand to some scripts

### DIFF
--- a/addon/appModules/emule.py
+++ b/addon/appModules/emule.py
@@ -148,7 +148,8 @@ class AppModule(appModuleHandler.AppModule):
 		# Translators: Message presented in input help mode.
 		# For instance: reads the search window, Statistics, IRC, etc.
 		description=_("Reports the current window."),
-		gesture="kb:control+shift+t"
+		gesture="kb:control+shift+t",
+		speakOnDemand=True
 	)
 	def script_where(self, gesture):
 		name = self.getName()
@@ -266,7 +267,8 @@ class AppModule(appModuleHandler.AppModule):
 	@script(
 		# Translators: Message presented in input help mode.
 		description=_("Reports first object of the Status Bar."),
-		gesture="kb:control+shift+q"
+		gesture="kb:control+shift+q",
+		speakOnDemand=True
 	)
 	def script_statusBarFirstChild(self, gesture):
 		if self.statusBarObj(0) is not None:
@@ -275,7 +277,8 @@ class AppModule(appModuleHandler.AppModule):
 	@script(
 		# Translators: Message presented in input help mode.
 		description=_("Reports second object of the Status Bar."),
-		gesture="kb:control+shift+w"
+		gesture="kb:control+shift+w",
+		speakOnDemand=True
 	)
 	def script_statusBarSecondChild(self, gesture):
 		if self.statusBarObj(1) is not None:
@@ -284,7 +287,8 @@ class AppModule(appModuleHandler.AppModule):
 	@script(
 		# Translators: Message presented in input help mode.
 		description=_("Reports third object of the Status Bar."),
-		gesture="kb:control+shift+e"
+		gesture="kb:control+shift+e",
+		speakOnDemand=True
 	)
 	def script_statusBarThirdChild(self, gesture):
 		if self.statusBarObj(2) is not None:
@@ -293,7 +297,8 @@ class AppModule(appModuleHandler.AppModule):
 	@script(
 		# Translators: Message presented in input help mode.
 		description=_("Reports fourth object of the Status Bar."),
-		gesture="kb:control+shift+r"
+		gesture="kb:control+shift+r",
+		speakOnDemand=True
 	)
 	def script_statusBarForthChild(self, gesture):
 		if self.statusBarObj(3) is not None:

--- a/buildVars.py
+++ b/buildVars.py
@@ -30,9 +30,9 @@ http://www.emule-project.net"""),
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3")
-	"addon_minimumNVDAVersion": "2022.1",
+	"addon_minimumNVDAVersion": "2024.1",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2023.1",
+	"addon_lastTestedNVDAVersion": "2024.1",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel": None,
 }


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
@Cyrilleb79 created ability to speak on demmand for NVDA 2024.1
### Description of how this pull request fixes the issue:
speakOnDemand is set to True for scripts, according to other commands of NVDA.
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
None, since the store can show just compatible add-ons, and some people has complained about long changelogs.