### PR TITLE
Better slider labelling

### DIFF
--- a/addon/appModules/emule.py
+++ b/addon/appModules/emule.py
@@ -70,7 +70,6 @@ class EmuleRowWithFakeNavigation(RowWithFakeNavigation):
 
 
 class BetterSlider(NVDAObjects.IAccessible.IAccessible):
-
 	def _get_value(self):
 		config = SearchConfig(directions=SearchDirections.TOP)
 		value = getLabel(self, config)


### PR DESCRIPTION
## Description

I created a new class, BetterSlider, to report/scroll the real value (e.g. 25 KB/S) instead of a percentage.

Always based on LabelAutofinderCore 🙂

P.S.: note that last beta version, uploaded on add-on store, lacks of the additional submodule folder, so it's onfortunately broken. Issue in GitHub action, maybe?
