### PR TITLE
Handle General Preferences slider

### DIFF
--- a/addon/appModules/emule.py
+++ b/addon/appModules/emule.py
@@ -73,7 +73,12 @@ class BetterSlider(NVDAObjects.IAccessible.IAccessible):
 	def _get_value(self):
 		config = SearchConfig(directions=SearchDirections.TOP)
 		value = getLabel(self, config)
-		return value
+		if self.name:
+			return value
+		# Slider in Preferences, General
+		if self.simpleNext:
+			return f"{super()._get_value()} {self.simpleNext.name}"
+		return super()._get_value()
 
 
 class RichEditCursorManager(CursorManager):
@@ -88,7 +93,7 @@ class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		if obj.role == Role.LISTITEM:
 			clsList.insert(0, EmuleRowWithFakeNavigation)
-		elif obj.role == Role.SLIDER and not obj.name:
+		elif obj.role == Role.SLIDER:
 			clsList.insert(0, BetterSlider)
 		elif obj.windowClassName == "RichEdit20W":
 			clsList.insert(0, RichEditCursorManager)


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
General Preferences has a slider not handler by getLabel
### Description of how this pull request fixes the issue:
If the slider doesn't have a name, the value is calculated adding self.simplenext.name, if simpleNext is found, to the original value.
findLabel is used when sliders have a name.
### Testing performed:
Tested locally.
### Known issues with pull request:
None.
### Change log entry:
None