### PR TITLE
Alternative to default improve better slider

### DIFF
--- a/.github/workflows/check-for-extended-ascii-and-utf-bom.yaml
+++ b/.github/workflows/check-for-extended-ascii-and-utf-bom.yaml
@@ -1,8 +1,0 @@
-name: Check that we dont have extended ascii or utf boms in our files
-
-on:
-  pull_request:
-
-jobs:
-  extendedAsciiAndBom:
-    uses: nvdaes/nvdaAddonWorkflows/.github/workflows/check-for-extended-ascii-and-utf-bom.yaml@main

--- a/addon/appModules/emule.py
+++ b/addon/appModules/emule.py
@@ -1,10 +1,10 @@
-# -*- coding: UTF-8 -*-
 # eMule app module
 # Copyright (C) 2012-2025 Noelia Ruiz Martínez, Alberto Buffolino
 # Released under GPL 2
 
 import appModuleHandler
 import addonHandler
+import config
 import eventHandler
 import mouseHandler
 import api
@@ -25,6 +25,10 @@ from .labelAutofinderCore import getLabel, SearchConfig, SearchDirections
 
 addonHandler.initTranslation()
 
+confspec: dict[str: str] = {
+	"alternativeGetValue": "boolean(default=False)",
+}
+config.conf.spec["eMule"] = confspec
 
 class EmuleRowWithFakeNavigation(RowWithFakeNavigation):
 	scriptCategory = addonHandler.getCodeAddon().manifest["summary"]
@@ -70,12 +74,12 @@ class EmuleRowWithFakeNavigation(RowWithFakeNavigation):
 
 
 class BetterSlider(NVDAObjects.IAccessible.IAccessible):
-	def _get_value(self):
+	def alternativeGetValue(self):
 		config = SearchConfig(directions=SearchDirections.TOP)
 		value = getLabel(self, config)
 		if self.name:
 			return value
-		# Slider in Preferences, General
+		# Slider in Preferences, General, in some systems.
 		if self.simpleNext:
 			return f"{super()._get_value()} {self.simpleNext.name}"
 		return super()._get_value()


### PR DESCRIPTION
- **Remove workflow to check for utf-8 BOM**
- **Add confspec for eMule and alternativeGetValue function**

<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None.
### Summary of the issue:
Some systems don't handle the default behavior to get sliders value.
### Description of how this pull request fixes the issue:
An alternative function is provided, which can be used if this is chosen via config.conf and an unassigned gesture.
### Testing performed:
Alternative has been tested locally.
### Known issues with pull request:
None.
### Change log entry:
* An unassigned command has been added to provide an alternative for systems which don't report value of sliders when it changes.